### PR TITLE
Configure Render static deploy and API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Key dependencies:
 - `@phosphor-icons/react` for consistent iconography
 - Tailwind CSS for styling with custom GIS-appropriate color scheme
 
+## Deployment
+
+The repository includes a [`render.yaml`](render.yaml) that provisions both the FastAPI backend and a Render Static Site for the Vite frontend.
+
+1. **Build the frontend** – Render runs `npm install && npm run build`, producing the production-ready assets in `dist/`.
+2. **Static site** – The static service publishes the `dist/` directory and exposes the frontend at `https://lotplan-frontend.onrender.com` by default.
+3. **API base URL** – During the build, the `VITE_API_BASE` environment variable is injected with the backend’s public URL so the frontend calls the deployed API instead of `localhost`.
+4. **CORS** – The backend’s `CORS_ORIGINS` includes both `http://localhost:5173` (for local development) and the Render static site origin.
+
+For alternative hosting targets (e.g. GitHub Pages), set the `VITE_BASE_PATH` environment variable before running `npm run build` to control the Vite `base` path.
+
 ## Production Considerations
 
 In a production environment, this application would integrate with:

--- a/render.yaml
+++ b/render.yaml
@@ -1,4 +1,16 @@
 services:
+  - type: static
+    name: lotplan-frontend
+    rootDirectory: .
+    buildCommand: npm install && npm run build
+    publishPath: dist
+    envVars:
+      - key: VITE_API_BASE
+        fromService:
+          type: web
+          name: lotplan-backend
+          property: url
+
   - type: web
     name: lotplan-backend
     env: docker
@@ -7,7 +19,7 @@ services:
     autoDeploy: true
     envVars:
       - key: CORS_ORIGINS
-        value: http://localhost:5173
+        value: http://localhost:5173,https://lotplan-frontend.onrender.com
       - key: HTTP_TIMEOUT_SECONDS
         value: "60"
       - key: ARCGIS_CONCURRENCY

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import createIconImportProxy from "@github/spark/vitePhosphorIconProxyPlugin";
 import { resolve } from "path";
 
 const projectRoot = process.env.PROJECT_ROOT || import.meta.dirname;
+const basePath = process.env.VITE_BASE_PATH ?? "/";
 
 export default defineConfig({
   plugins: [
@@ -20,7 +21,7 @@ export default defineConfig({
       "@": resolve(projectRoot, "src"),
     },
   },
-  // IMPORTANT: must be '/<repo>/' for GitHub Project Pages
-  // Ensures proper deployment to https://shaunmcn2001.github.io/qlds-mapper-queensla/
-  base: "/qlds-mapper-queensla/",
+  // Allow the deploy target to control the base path. Render deployments serve the
+  // site from '/', while GitHub Pages can override via VITE_BASE_PATH.
+  base: basePath,
 });


### PR DESCRIPTION
## Summary
- add a Render static site definition that builds the Vite frontend and publishes `dist/`
- inject the backend URL into the frontend build and relax backend CORS for the static host
- allow overriding Vite's base path via `VITE_BASE_PATH` and document Render deployment steps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8dd621f548327876679dc240a4297