### PR TITLE
Add defined flood events ArcGIS layer

### DIFF
--- a/backend/app/config/layers.yaml
+++ b/backend/app/config/layers.yaml
@@ -27,3 +27,18 @@ services:
     name_template: "RVM ${rvm_cat}"
     style: { line_width: 1, line_opacity: 0.9, poly_opacity: 0.30, color: "#2ca02c" }
     popup: { order: ["rvm_cat","map_no","version"], hide_null: true }
+
+  - id: flood_events
+    label: "Flood Mapping (Defined Flood Events)"
+    url: "https://spatial-gis.information.qld.gov.au/arcgis/rest/services/DisasterManagement/DefinedFloodEvents/MapServer/0"
+    fields:
+      include: ["EVENT_NAME","EVENT_YEAR","SOURCE","GAUGE_NAME","AREA_HA","OBJECTID"]
+      aliases:
+        EVENT_NAME: "Event name"
+        EVENT_YEAR: "Year"
+        SOURCE: "Data source"
+        GAUGE_NAME: "Gauge"
+        AREA_HA: "Area (ha)"
+    name_template: "${EVENT_NAME} (${EVENT_YEAR})"
+    style: { line_width: 1, line_opacity: 0.9, poly_opacity: 0.25, color: "#ff7f0e" }
+    popup: { order: ["EVENT_NAME","EVENT_YEAR","SOURCE","GAUGE_NAME","AREA_HA"], hide_null: true }


### PR DESCRIPTION
### **User description**
## Summary
- register the Defined Flood Events ArcGIS layer in the layer catalogue
- expose the layer metadata, including aliases, styling, and popup configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8e036a290832780de0d082801399e


___

### **PR Type**
Enhancement


___

### **Description**
- Add new flood events ArcGIS layer configuration

- Configure field aliases and popup display settings

- Set styling with orange color and transparency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  config["layers.yaml config"] --> flood["Flood Events Layer"]
  flood --> fields["Field Aliases"]
  flood --> style["Orange Styling"]
  flood --> popup["Popup Configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layers.yaml</strong><dd><code>Add flood events layer configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/config/layers.yaml

<ul><li>Add new <code>flood_events</code> layer configuration with ArcGIS URL<br> <li> Define field aliases for event name, year, source, gauge, and area<br> <li> Configure orange styling with transparency and popup field ordering</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/qlds-mapper-queensla/pull/36/files#diff-3668aaff9fb9d19b2da08ea0eac4522735e4c721d2d9ca663512c63e886d61ee">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

