### PR TITLE
feat: add offline-friendly UI and backend debugger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,187 +1,485 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { useToast } from "./components/Toast";
 import LoadingOverlay from "./components/LoadingOverlay";
 import MapView from "./components/MapView";
+import BackendDebugger from "./components/BackendDebugger";
+import { useToast } from "./components/Toast";
 import { API_BASE } from "./lib/api";
-
 import {
-  normalizeLotPlan,
-  resolveParcels,
+  exportData,
   getLayers,
   intersectLayers,
-  exportData,
+  normalizeLotPlan,
+  resolveParcels,
+  type FeatureMap,
+  type LayerList,
+  type ParcelList,
 } from "./lib/gis";
 
-type LayerMeta = { id: string; label: string };
+function countFeatures(features: FeatureMap): number {
+  return Object.entries(features)
+    .filter(([key]) => key !== "meta")
+    .reduce((acc, [, value]) => (Array.isArray(value) ? acc + value.length : acc), 0);
+}
+
+function toRelativePath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const base = new URL(API_BASE);
+    if (parsed.origin === base.origin) {
+      return parsed.pathname + (parsed.search || "");
+    }
+    return url;
+  } catch (err) {
+    return url;
+  }
+}
+
+type FeaturePreview = {
+  id: string;
+  title: string;
+  attributes: Array<{ label: string; value: string }>; 
+};
+
+type LayerPreview = {
+  id: string;
+  label: string;
+  color: string;
+  description?: string;
+  total: number;
+  previews: FeaturePreview[];
+};
+
+const DEFAULT_LAYER_COLORS = [
+  "#2563eb",
+  "#f97316",
+  "#10b981",
+  "#8b5cf6",
+  "#f43f5e",
+  "#0ea5e9",
+];
 
 export default function App() {
-  const [lotplan, setLotplan] = useState("3/RP67254");
-
-  const [layers, setLayers] = useState<LayerMeta[]>([]);
-  const [selected, setSelected] = useState<string[]>([]);
-
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [apiNotice, setApiNotice] = useState<string | null>(null);
-
-  const [parcels, setParcels] = useState<any[]>([]);
-  const [featuresByLayer, setFeaturesByLayer] = useState<Record<string, any[]>>({});
-
   const toast = useToast();
 
+  const [lotPlanInput, setLotPlanInput] = useState("3/RP67254");
+  const [layers, setLayers] = useState<LayerList>(() => [] as LayerList);
+  const [selectedLayers, setSelectedLayers] = useState<string[]>([]);
+  const [parcels, setParcels] = useState<ParcelList>(() => [] as ParcelList);
+  const [featuresByLayer, setFeaturesByLayer] = useState<FeatureMap>(() => ({} as FeatureMap));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
   useEffect(() => {
-    getLayers()
-      .then((arr) => {
-        setLayers(arr);
-        // Preselect first two layers if available (so list isn't empty)
-        setSelected(arr.slice(0, 2).map(l => l.id));
-        const hasApiError = typeof arr.meta?.error === "string" && arr.meta.error.length > 0;
-        setApiNotice(hasApiError ? "API temporarily unreachable; showing empty state." : null);
+    let cancelled = false;
+    async function bootstrap() {
+      setLoading(true);
+      try {
+        const layerList = await getLayers();
+        if (cancelled) return;
+        setLayers(layerList);
+        setSelectedLayers((prev) => {
+          const next = prev.filter((id) => layerList.some((layer) => layer.id === id));
+          if (next.length > 0) return next;
+          return layerList.slice(0, Math.min(3, layerList.length)).map((layer) => layer.id);
+        });
+        if (layerList.meta?.message) {
+          setNotice(layerList.meta.message);
+          if (layerList.meta?.fallback) {
+            toast.push("Loaded sample datasets while the backend is offline.", "info");
+          }
+        } else {
+          setNotice(null);
+        }
         setError(null);
-      })
-      .catch((e) => {
-        const message = e instanceof Error ? e.message : String(e);
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
         setError(message);
-        setApiNotice(message);
-      });
-  }, []);
+        setNotice(message);
+        toast.push(message, "error");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, [toast]);
+
+  const layerColorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    layers.forEach((layer, idx) => {
+      map[layer.id] = layer.style?.color || DEFAULT_LAYER_COLORS[idx % DEFAULT_LAYER_COLORS.length];
+    });
+    return map;
+  }, [layers]);
+
+  const layerPreviews = useMemo<LayerPreview[]>(() => {
+    return selectedLayers
+      .map((layerId, idx) => {
+        const layer = layers.find((item) => item.id === layerId);
+        if (!layer) return null;
+        const raw = (featuresByLayer as Record<string, any>)[layerId];
+        const features = Array.isArray(raw) ? raw : [];
+        const displayFields =
+          layer.popup?.order?.length ? layer.popup.order : layer.fields?.include ?? [];
+        const previewFields = displayFields.slice(0, 3);
+        const previews: FeaturePreview[] = features.slice(0, 3).map((feature) => ({
+          id: feature.id,
+          title:
+            feature.displayName ||
+            (previewFields[0]
+              ? String(feature.properties?.[previewFields[0]] ?? `Feature ${feature.id}`)
+              : `Feature ${feature.id}`),
+          attributes: previewFields.map((field) => ({
+            label: layer.fields?.aliases?.[field] || field,
+            value: String(feature.properties?.[field] ?? "—"),
+          })),
+        }));
+        return {
+          id: layer.id,
+          label: layer.label,
+          color: layerColorMap[layer.id] || DEFAULT_LAYER_COLORS[idx % DEFAULT_LAYER_COLORS.length],
+          description: layer.description,
+          total: features.length,
+          previews,
+        } as LayerPreview;
+      })
+      .filter(Boolean) as LayerPreview[];
+  }, [selectedLayers, layers, featuresByLayer, layerColorMap]);
+
+  const activeParcel = parcels[0];
+  const totalFeatureCount = useMemo(() => countFeatures(featuresByLayer), [featuresByLayer]);
+  const usingFallback = Boolean(
+    layers.meta?.fallback || parcels.meta?.fallback || featuresByLayer.meta?.fallback,
+  );
+
+  function updateNoticeFromMeta(...messages: Array<string | null | undefined>) {
+    const first = messages.find((msg) => typeof msg === "string" && msg.trim().length > 0);
+    setNotice(first || null);
+  }
 
   async function runIntersect() {
+    const normalized = normalizeLotPlan(lotPlanInput);
+    if (normalized.length === 0) {
+      const message = "Enter a valid Queensland lot/plan combination (e.g. 3/RP67254).";
+      setError(message);
+      setNotice(message);
+      toast.push(message, "error");
+      return;
+    }
+
     setError(null);
     setLoading(true);
-    setFeaturesByLayer({});
+    setFeaturesByLayer({} as FeatureMap);
+
     try {
       toast.push("Resolving parcel…");
-      const normalized = normalizeLotPlan(lotplan);
       const resolved = await resolveParcels(normalized);
       if (!resolved.length || !resolved[0]?.geometry) {
-        setParcels([]);
+        setParcels([] as ParcelList);
         throw new Error("Parcel not found for that lot/plan.");
       }
       setParcels(resolved);
-      toast.push("Parcel resolved", "success");
+      if (resolved.meta?.fallback) {
+        toast.push("Parcel service offline – using sample parcel geometry.", "info");
+      } else {
+        toast.push("Parcel resolved", "success");
+      }
 
-      if (selected.length === 0) {
-        toast.push("No layers selected — showing parcel only", "info");
-        setLoading(false);
+      if (selectedLayers.length === 0) {
+        updateNoticeFromMeta(resolved.meta?.message, layers.meta?.message);
+        toast.push("No datasets selected — displaying parcel outline only.", "info");
         return;
       }
 
       toast.push("Intersecting layers…");
-      const inter = await intersectLayers(resolved[0], selected);
-      setFeaturesByLayer(inter);
-      setApiNotice(null);
-      toast.push("Intersect complete", "success");
-    } catch (e: any) {
-      const message = e?.message || String(e);
-      setError(message);
-      toast.push(message, "error");
-      if (typeof message === "string" && message.toLowerCase().includes("temporarily unreachable")) {
-        setApiNotice("API temporarily unreachable; showing empty state.");
+      const intersections = await intersectLayers(resolved[0], selectedLayers);
+      setFeaturesByLayer(intersections);
+      if (intersections.meta?.fallback) {
+        toast.push("Overlay service offline – showing curated sample intersections.", "info");
+      } else {
+        toast.push("Intersect complete", "success");
       }
+
+      updateNoticeFromMeta(
+        intersections.meta?.message,
+        resolved.meta?.message,
+        layers.meta?.message,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      setNotice(message);
+      toast.push(message, "error");
     } finally {
       setLoading(false);
     }
   }
 
   async function runExport() {
-    if (!parcels.length) return;
+    if (!parcels.length) {
+      toast.push("Resolve a parcel before exporting data.", "info");
+      return;
+    }
+
+    setLoading(true);
     try {
       toast.push("Preparing KMZ…");
       await exportData(parcels[0], featuresByLayer);
-      setApiNotice(null);
       toast.push("Download started", "success");
-    } catch (e: any) {
-      const message = e?.message || String(e);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       setError(message);
+      setNotice(message);
       toast.push(message, "error");
-      if (typeof message === "string" && message.toLowerCase().includes("temporarily unreachable")) {
-        setApiNotice("API temporarily unreachable; showing empty state.");
-      }
+    } finally {
+      setLoading(false);
     }
   }
 
-  const canExport = useMemo(() => parcels.length > 0, [parcels]);
-
   return (
-    <div className="mx-auto max-w-6xl p-6 space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-bold">QLDS Mapper</h1>
-        <p className="text-slate-600">
-          Enter a Queensland Lot/Plan, pick datasets, intersect, and export KMZ.
-        </p>
-      </header>
+    <div className="min-h-screen bg-slate-50">
+      <main className="mx-auto max-w-6xl px-6 py-10 space-y-8">
+        <header className="space-y-3">
+          <span className="inline-flex items-center gap-2 rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700">
+            QLDS Mapper
+          </span>
+          <h1 className="text-3xl font-bold text-slate-900">
+            Queensland parcel & overlay explorer
+          </h1>
+          <p className="max-w-3xl text-sm text-slate-600">
+            Analyse Queensland land parcels against public GIS datasets. The UI now mirrors the
+            production site at <a className="text-blue-600 underline" href="https://qlds-mapper-queensla-1.onrender.com" target="_blank" rel="noreferrer">qlds-mapper-queensla-1.onrender.com</a> and gracefully falls back to curated sample data whenever the backend at {toRelativePath(API_BASE)} is unreachable.
+          </p>
+        </header>
 
-      {apiNotice && (
-        <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-          {apiNotice}
-        </div>
-      )}
+        {notice && (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-900 shadow-sm">
+            {notice}
+          </div>
+        )}
 
-      <section className="grid gap-4 md:grid-cols-[2fr_3fr]">
-        <div className="space-y-3">
-          <label className="block text-sm font-medium">Lot/Plan</label>
-          <input
-            value={lotplan}
-            onChange={(e) => setLotplan(e.target.value)}
-            placeholder="e.g. 3/RP67254 or 3RP67254"
-            className="w-full rounded-lg border bg-white p-3 shadow-sm outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          <div className="flex gap-2">
-            <button
-              onClick={runIntersect}
-              disabled={loading}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-white shadow hover:bg-blue-700 disabled:opacity-50"
-            >
-              {loading ? "Working…" : "Resolve & Intersect"}
-            </button>
-            <button
-              onClick={runExport}
-              disabled={!canExport}
-              className="rounded-lg bg-emerald-600 px-4 py-2 text-white shadow hover:bg-emerald-700 disabled:opacity-50"
-            >
-              Export KMZ
-            </button>
+        <section className="grid gap-6 lg:grid-cols-[360px,1fr]">
+          <div className="space-y-6">
+            <div className="rounded-2xl border bg-white p-6 shadow-sm space-y-4">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-slate-900">1. Choose a lot/plan</h2>
+                <p className="text-sm text-slate-500">
+                  Enter a Queensland lot/plan descriptor. The mapper normalises the value, resolves the
+                  cadastral parcel, and highlights it on the map.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="lot-plan" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Lot/Plan
+                </label>
+                <input
+                  id="lot-plan"
+                  value={lotPlanInput}
+                  onChange={(event) => setLotPlanInput(event.target.value)}
+                  placeholder="e.g. 3/RP67254 or L3 RP67254"
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-inner outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30"
+                />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={runIntersect}
+                  disabled={loading}
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {loading ? "Working…" : "Resolve & intersect"}
+                </button>
+                <button
+                  onClick={runExport}
+                  disabled={loading}
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-emerald-500 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Export KMZ
+                </button>
+              </div>
+              {activeParcel && (
+                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
+                  <p className="font-semibold text-slate-700">Active parcel</p>
+                  <div className="mt-1 grid grid-cols-2 gap-2">
+                    <div>
+                      <span className="block text-[10px] uppercase text-slate-400">Lot/Plan</span>
+                      <span className="font-mono text-sm">{activeParcel.lotPlan}</span>
+                    </div>
+                    {Array.isArray(activeParcel.centroid) && (
+                      <div>
+                        <span className="block text-[10px] uppercase text-slate-400">Centroid</span>
+                        <span className="font-mono text-sm">
+                          {activeParcel.centroid[1].toFixed(4)}, {activeParcel.centroid[0].toFixed(4)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-2xl border bg-white p-6 shadow-sm space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">2. Select datasets</h2>
+                  <p className="text-sm text-slate-500">
+                    Toggle the Queensland Government layers you want to intersect with the parcel.
+                  </p>
+                </div>
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                  {selectedLayers.length} selected
+                </span>
+              </div>
+              <div className="max-h-72 space-y-2 overflow-y-auto pr-2">
+                {layers.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+                    No datasets loaded yet. Check the backend status below to diagnose the connection.
+                  </div>
+                ) : (
+                  layers.map((layer, index) => {
+                    const checked = selectedLayers.includes(layer.id);
+                    const color = layerColorMap[layer.id] || DEFAULT_LAYER_COLORS[index % DEFAULT_LAYER_COLORS.length];
+                    return (
+                      <label
+                        key={layer.id}
+                        className="flex cursor-pointer items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 shadow-sm transition hover:border-blue-400 hover:bg-blue-50/40"
+                      >
+                        <input
+                          type="checkbox"
+                          className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                          checked={checked}
+                          onChange={() => {
+                            setSelectedLayers((prev) =>
+                              prev.includes(layer.id)
+                                ? prev.filter((id) => id !== layer.id)
+                                : [...prev, layer.id],
+                            );
+                          }}
+                        />
+                        <div className="flex-1 space-y-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium text-slate-900">{layer.label}</span>
+                            <span
+                              className="h-2.5 w-2.5 rounded-full"
+                              style={{ backgroundColor: color }}
+                            />
+                            <span className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+                              {layer.id}
+                            </span>
+                          </div>
+                          {layer.description && (
+                            <p className="text-xs text-slate-500">{layer.description}</p>
+                          )}
+                        </div>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            </div>
           </div>
 
-          <div className="space-y-2">
-            <label className="block text-sm font-medium">Datasets</label>
-            <div className="max-h-60 overflow-auto rounded-lg border bg-white p-3 shadow-sm">
-              {layers.length === 0 ? (
-                <p className="text-sm text-slate-500">No layers available. Check backend /layers and CORS.</p>
+          <div className="space-y-6">
+            <div className="h-[460px] overflow-hidden rounded-2xl border bg-white shadow-sm">
+              <MapView parcels={parcels} featuresByLayer={featuresByLayer} layerStyles={layerColorMap} />
+            </div>
+
+            <div className="rounded-2xl border bg-white p-6 shadow-sm space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">3. Feature preview</h2>
+                  <p className="text-sm text-slate-500">
+                    Summaries of the latest intersections. Sample data is shown whenever the backend is
+                    unreachable so you can still explore the UI.
+                  </p>
+                </div>
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                  {totalFeatureCount} feature{totalFeatureCount === 1 ? "" : "s"}
+                </span>
+              </div>
+
+              {layerPreviews.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+                  Run an intersection to preview results or use the backend debugger below to troubleshoot
+                  connectivity.
+                </div>
               ) : (
-                <div className="grid gap-2 sm:grid-cols-2">
-                  {layers.map((l) => (
-                    <label key={l.id} className="flex items-center gap-2 rounded border p-2">
-                      <input
-                        type="checkbox"
-                        checked={selected.includes(l.id)}
-                        onChange={() => {
-                          if (selected.includes(l.id))
-                            setSelected(selected.filter((x) => x !== l.id));
-                          else setSelected([...selected, l.id]);
-                        }}
-                      />
-                      <span className="font-medium">{l.label}</span>
-                      <span className="text-xs text-slate-500 ml-auto">{l.id}</span>
-                    </label>
+                <div className="space-y-4">
+                  {layerPreviews.map((preview) => (
+                    <div key={preview.id} className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="h-3 w-3 rounded-full border border-slate-200"
+                          style={{ backgroundColor: preview.color }}
+                        />
+                        <div className="flex-1">
+                          <p className="text-sm font-semibold text-slate-800">{preview.label}</p>
+                          {preview.description && (
+                            <p className="text-xs text-slate-500">{preview.description}</p>
+                          )}
+                        </div>
+                        <span className="rounded-full bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-600">
+                          {preview.total} feature{preview.total === 1 ? "" : "s"}
+                        </span>
+                      </div>
+                      {preview.previews.length === 0 ? (
+                        <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-3 text-xs text-slate-500">
+                          No intersecting features returned yet.
+                        </div>
+                      ) : (
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          {preview.previews.map((item) => (
+                            <div key={item.id} className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 text-xs text-slate-600">
+                              <p className="text-sm font-semibold text-slate-700">{item.title}</p>
+                              <dl className="mt-2 space-y-1">
+                                {item.attributes.map((attr) => (
+                                  <div key={attr.label} className="flex justify-between gap-2">
+                                    <dt className="text-[11px] font-medium text-slate-500">{attr.label}</dt>
+                                    <dd className="truncate font-mono text-[11px] text-slate-700">
+                                      {attr.value}
+                                    </dd>
+                                  </div>
+                                ))}
+                              </dl>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   ))}
                 </div>
               )}
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="rounded-lg border bg-white p-2 shadow-sm min-h-[420px]">
-          <MapView parcels={parcels} featuresByLayer={featuresByLayer} />
-        </div>
-      </section>
+        <BackendDebugger />
 
-      {error && <p className="text-red-600 text-sm">{error}</p>}
+        {error && (
+          <div className="rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm text-red-700 shadow-sm">
+            {error}
+          </div>
+        )}
 
-      <footer className="pt-6 text-xs text-slate-500">
-        API: <code>{API_BASE}</code>
-      </footer>
+        <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-6 text-xs text-slate-500">
+          <div className="space-y-1">
+            <div>
+              API target: <code className="font-mono text-slate-700">{API_BASE}</code>
+            </div>
+            <div>Frontend build mirrors: qlds-mapper-queensla-1.onrender.com</div>
+          </div>
+          <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 shadow-sm">
+            <span className={`h-2.5 w-2.5 rounded-full ${usingFallback ? "bg-amber-500" : "bg-emerald-500"}`} />
+            <span className="font-semibold text-slate-600">
+              {usingFallback ? "Sample data active (backend offline)" : "Live backend connection"}
+            </span>
+          </div>
+        </footer>
+      </main>
 
       <LoadingOverlay show={loading} label={error ? "Retrying…" : "Working…"} />
     </div>

--- a/src/components/BackendDebugger.tsx
+++ b/src/components/BackendDebugger.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import { API_BASE } from "@/lib/api";
+import { getBackendHistory, subscribeBackendEvents, type BackendEvent } from "@/lib/debug";
+import { fetchWithTimeout } from "@/lib/http";
+import { createFallbackParcels, createFallbackFeatures } from "@/lib/fallbackData";
+
+const IMPORTANT_ENDPOINTS = [
+  { id: "layers", method: "GET", suffix: "/layers", label: "GET /layers" },
+  { id: "resolve", method: "POST", suffix: "/parcel/resolve", label: "POST /parcel/resolve" },
+  { id: "intersect", method: "POST", suffix: "/intersect", label: "POST /intersect" },
+  { id: "export", method: "POST", suffix: "/export/kml", label: "POST /export/kml" },
+];
+
+function relativePath(url: string) {
+  if (!url) return url;
+  try {
+    const parsed = new URL(url);
+    const base = new URL(API_BASE);
+    if (parsed.origin === base.origin) return parsed.pathname;
+    return url;
+  } catch {
+    return url;
+  }
+}
+
+function formatTime(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString();
+}
+
+function statusFor(event?: BackendEvent) {
+  if (!event) return { label: "No data", tone: "bg-slate-200 text-slate-600", detail: "No requests yet" };
+  if (event.ok) return { label: `HTTP ${event.status}`, tone: "bg-emerald-100 text-emerald-700", detail: "Last call succeeded" };
+  if (event.fallback)
+    return {
+      label: "Offline",
+      tone: "bg-amber-100 text-amber-700",
+      detail: event.errorMessage || "Safe fetch returned fallback data",
+    };
+  return {
+    label: event.status ? `HTTP ${event.status}` : "Error",
+    tone: "bg-red-100 text-red-700",
+    detail: event.errorMessage || "Request failed",
+  };
+}
+
+export default function BackendDebugger() {
+  const [events, setEvents] = useState<BackendEvent[]>(() => getBackendHistory(12));
+  const [running, setRunning] = useState(false);
+  const [lastRun, setLastRun] = useState<number | null>(null);
+
+  useEffect(() => {
+    return subscribeBackendEvents((event) => {
+      setEvents((prev) => [event, ...prev].slice(0, 20));
+    });
+  }, []);
+
+  const endpointStatus = useMemo(() => {
+    return IMPORTANT_ENDPOINTS.map((endpoint) => {
+      const match = events.find(
+        (event) => event.method === endpoint.method && event.path.endsWith(endpoint.suffix),
+      );
+      const state = statusFor(match);
+      return { ...endpoint, state, event: match };
+    });
+  }, [events]);
+
+  const diagnostics = useMemo(
+    () => [
+      () => fetchWithTimeout("/layers", { timeoutMs: 8000 }),
+      () =>
+        fetchWithTimeout("/parcel/resolve", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lotplan: createFallbackParcels()[0]?.lotPlan || "3/RP67254" }),
+          timeoutMs: 8000,
+        }),
+      () => {
+        const parcel = createFallbackParcels()[0];
+        const layers = Object.keys(createFallbackFeatures());
+        return fetchWithTimeout("/intersect", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ parcel: parcel?.geometry, layer_ids: layers }),
+          timeoutMs: 10000,
+        });
+      },
+      () => {
+        const parcel = createFallbackParcels()[0];
+        const features = createFallbackFeatures();
+        const payload = {
+          parcel: parcel?.geometry,
+          layers: Object.entries(features).map(([id, feats]) => ({ id, label: id, features: feats })),
+        };
+        return fetchWithTimeout("/export/kml", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          timeoutMs: 10000,
+        });
+      },
+    ],
+    [],
+  );
+
+  async function runDiagnostics() {
+    if (running) return;
+    setRunning(true);
+    setLastRun(Date.now());
+    for (const task of diagnostics) {
+      try {
+        const response = await task();
+        await response.clone().json().catch(() => null);
+      } catch (err) {
+        // safeFetch already records the failure; swallowing keeps the loop going
+        console.error("Diagnostics error", err);
+      }
+    }
+    setRunning(false);
+  }
+
+  return (
+    <section className="rounded-2xl border bg-white p-6 shadow-sm space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Backend debugger</h2>
+          <p className="text-sm text-slate-500">
+            Live visibility into the Render backend at <code className="font-mono text-xs text-slate-600">{API_BASE}</code>.
+            Trigger diagnostics to ping each endpoint and inspect the last responses.
+          </p>
+        </div>
+        <button
+          onClick={runDiagnostics}
+          disabled={running}
+          className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {running ? "Running checks…" : "Run diagnostics"}
+        </button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {endpointStatus.map((endpoint) => (
+          <div key={endpoint.id} className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 shadow-inner">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {endpoint.label}
+            </p>
+            <div className={`mt-2 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${endpoint.state.tone}`}>
+              {endpoint.state.label}
+            </div>
+            <p className="mt-2 text-xs text-slate-500">{endpoint.state.detail}</p>
+            {endpoint.event && (
+              <p className="mt-2 text-[11px] text-slate-400">
+                Last: {formatTime(endpoint.event.timestamp)} via {relativePath(endpoint.event.path)}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>Recent backend events</span>
+          {lastRun && <span>Diagnostics last ran at {new Date(lastRun).toLocaleTimeString()}</span>}
+        </div>
+        <div className="max-h-48 overflow-y-auto rounded-xl border border-slate-200 bg-slate-50 p-3 text-[11px] text-slate-600">
+          {events.length === 0 ? (
+            <p className="text-center text-slate-500">No API calls recorded yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {events.map((event) => (
+                <li key={event.id} className="flex items-start justify-between gap-3 border-b border-slate-200 pb-2 last:border-b-0 last:pb-0">
+                  <div>
+                    <div className="font-semibold text-slate-700">
+                      {event.method} {relativePath(event.path)}
+                    </div>
+                    <div className="text-slate-500">
+                      {event.ok ? `HTTP ${event.status}` : event.errorMessage || "Error"}
+                      {event.fallback ? " · fallback response" : ""}
+                    </div>
+                  </div>
+                  <span className="whitespace-nowrap text-slate-400">{formatTime(event.timestamp)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,0 +1,43 @@
+export type BackendEvent = {
+  id: number;
+  path: string;
+  method: string;
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  errorMessage?: string;
+  fallback?: boolean;
+  timestamp: number;
+};
+
+type Listener = (event: BackendEvent) => void;
+
+let counter = 0;
+const listeners = new Set<Listener>();
+const history: BackendEvent[] = [];
+
+function push(event: Omit<BackendEvent, "id">): BackendEvent {
+  const enriched: BackendEvent = { ...event, id: ++counter };
+  history.push(enriched);
+  if (history.length > 100) history.splice(0, history.length - 100);
+  for (const listener of listeners) listener(enriched);
+  return enriched;
+}
+
+export function logBackendEvent(event: Omit<BackendEvent, "id">) {
+  push(event);
+}
+
+export function subscribeBackendEvents(listener: Listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getBackendHistory(limit = 20): BackendEvent[] {
+  return history.slice(-limit).reverse();
+}
+
+export function clearBackendHistory() {
+  history.splice(0, history.length);
+  counter = 0;
+}

--- a/src/lib/fallbackData.ts
+++ b/src/lib/fallbackData.ts
@@ -1,0 +1,232 @@
+import type { Feature, LayerConfig, Parcel } from "@/types";
+
+type DeepPartial<T> = { [K in keyof T]: T[K] extends object ? DeepPartial<T[K]> : T[K] };
+
+const parcelPolygon: Parcel["geometry"] = {
+  type: "Polygon",
+  coordinates: [
+    [
+      [153.0218, -27.4673],
+      [153.0275, -27.4674],
+      [153.0293, -27.4719],
+      [153.0244, -27.4741],
+      [153.0199, -27.4712],
+      [153.0218, -27.4673],
+    ],
+  ],
+};
+
+const makeFeatureGeometry = (
+  offsets: Array<[number, number]>,
+): Feature["geometry"] => ({
+  type: "Polygon",
+  coordinates: [
+    offsets.map(([dx, dy]) => [parcelPolygon.coordinates[0][0][0] + dx, parcelPolygon.coordinates[0][0][1] + dy]),
+  ],
+});
+
+const SAMPLE_PARCELS: Parcel[] = [
+  {
+    id: "SAMPLE-3/RP67254",
+    lotPlan: "3/RP67254",
+    geometry: parcelPolygon,
+    centroid: [parcelPolygon.coordinates[0][0][0] + 0.003, parcelPolygon.coordinates[0][0][1] - 0.0025],
+    area: 0,
+  },
+];
+
+const SAMPLE_LAYERS: LayerConfig[] = [
+  {
+    id: "environmental_risk",
+    label: "Environmental Risk Zones",
+    description: "Demonstration overlays from Queensland open data.",
+    fields: {
+      include: ["ZONE", "SOURCE", "UPDATED"],
+      aliases: {
+        ZONE: "Zone",
+        SOURCE: "Source",
+        UPDATED: "Updated",
+      },
+    },
+    style: {
+      color: "#2563eb",
+      lineWidth: 2,
+      lineOpacity: 0.9,
+      polyOpacity: 0.25,
+    },
+    popup: {
+      order: ["ZONE", "SOURCE", "UPDATED"],
+      hideNull: true,
+    },
+  },
+  {
+    id: "heritage_register",
+    label: "State Heritage Register",
+    description: "Sample of Queensland heritage places with attributes.",
+    fields: {
+      include: ["PLACE_NAME", "PLACE_TYPE", "LOCAL_GOV"],
+      aliases: {
+        PLACE_NAME: "Place",
+        PLACE_TYPE: "Type",
+        LOCAL_GOV: "Local Government",
+      },
+    },
+    style: {
+      color: "#f97316",
+      lineWidth: 2,
+      lineOpacity: 0.9,
+      polyOpacity: 0.2,
+    },
+    popup: {
+      order: ["PLACE_NAME", "PLACE_TYPE", "LOCAL_GOV"],
+      hideNull: true,
+    },
+  },
+  {
+    id: "flood_hazard",
+    label: "Flood Hazard Areas",
+    description: "Illustrative flood extent polygons for demo purposes.",
+    fields: {
+      include: ["HAZARD", "PROBABILITY", "UPDATED"],
+      aliases: {
+        HAZARD: "Hazard",
+        PROBABILITY: "Probability",
+        UPDATED: "Updated",
+      },
+    },
+    style: {
+      color: "#10b981",
+      lineWidth: 2,
+      lineOpacity: 0.85,
+      polyOpacity: 0.2,
+    },
+    popup: {
+      order: ["HAZARD", "PROBABILITY", "UPDATED"],
+      hideNull: true,
+    },
+  },
+];
+
+const SAMPLE_FEATURES: Record<string, Feature[]> = {
+  environmental_risk: [
+    {
+      id: "env-1",
+      layerId: "environmental_risk",
+      displayName: "Bushfire management area",
+      geometry: makeFeatureGeometry([
+        [0.001, 0.0002],
+        [0.004, 0.0005],
+        [0.0045, -0.0028],
+        [0.0008, -0.003],
+        [0.001, 0.0002],
+      ]),
+      properties: {
+        ZONE: "Bushfire prone area",
+        SOURCE: "Sample overlay",
+        UPDATED: "2024-07-01",
+      },
+    },
+    {
+      id: "env-2",
+      layerId: "environmental_risk",
+      displayName: "Protected vegetation",
+      geometry: makeFeatureGeometry([
+        [-0.002, 0.001],
+        [0.0015, 0.0012],
+        [0.0012, -0.0015],
+        [-0.0025, -0.0017],
+        [-0.002, 0.001],
+      ]),
+      properties: {
+        ZONE: "Regulated vegetation",
+        SOURCE: "Sample overlay",
+        UPDATED: "2024-05-20",
+      },
+    },
+  ],
+  heritage_register: [
+    {
+      id: "heritage-1",
+      layerId: "heritage_register",
+      displayName: "Old Post Office",
+      geometry: makeFeatureGeometry([
+        [-0.001, -0.0005],
+        [0.001, -0.0004],
+        [0.0011, -0.0022],
+        [-0.0009, -0.0023],
+        [-0.001, -0.0005],
+      ]),
+      properties: {
+        PLACE_NAME: "Sample Post Office",
+        PLACE_TYPE: "State heritage place",
+        LOCAL_GOV: "Brisbane",
+      },
+    },
+  ],
+  flood_hazard: [
+    {
+      id: "flood-1",
+      layerId: "flood_hazard",
+      displayName: "1% AEP Flood extent",
+      geometry: makeFeatureGeometry([
+        [-0.0035, 0.001],
+        [0.001, 0.0015],
+        [0.002, -0.002],
+        [-0.003, -0.003],
+        [-0.0035, 0.001],
+      ]),
+      properties: {
+        HAZARD: "1% AEP",
+        PROBABILITY: "High",
+        UPDATED: "2023-11-15",
+      },
+    },
+    {
+      id: "flood-2",
+      layerId: "flood_hazard",
+      displayName: "Annual inundation",
+      geometry: makeFeatureGeometry([
+        [-0.0025, 0.002],
+        [0.0005, 0.0025],
+        [0.0015, 0.0002],
+        [-0.0015, -0.0006],
+        [-0.0025, 0.002],
+      ]),
+      properties: {
+        HAZARD: "Frequent",
+        PROBABILITY: "Medium",
+        UPDATED: "2024-02-08",
+      },
+    },
+  ],
+};
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function createFallbackParcels(): Parcel[] {
+  return clone(SAMPLE_PARCELS);
+}
+
+export function createFallbackLayers(): LayerConfig[] {
+  return clone(SAMPLE_LAYERS);
+}
+
+export function createFallbackFeatures(): Record<string, Feature[]> {
+  return clone(SAMPLE_FEATURES);
+}
+
+export type FallbackSnapshot = {
+  parcels: DeepPartial<Parcel>[];
+  layers: DeepPartial<LayerConfig>[];
+  features: Record<string, DeepPartial<Feature>[]>;
+};
+
+export function getFallbackSnapshot(): FallbackSnapshot {
+  return {
+    parcels: clone(SAMPLE_PARCELS),
+    layers: clone(SAMPLE_LAYERS),
+    features: clone(SAMPLE_FEATURES),
+  };
+}


### PR DESCRIPTION
## Summary
- rebuild the QLDS Mapper front-end to mirror the production layout, highlight dataset selections, and keep the UI usable with sample content when the API is offline
- add a Leaflet-based map renderer plus curated sample datasets so parcel and layer previews remain interactive without a backend connection
- introduce a backend debugger panel, safe fetch logging, and fallback utilities to surface connection issues and diagnostics

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint is not configured for the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c9501ed10c832781e29ef59a752a78