### PR TITLE
Adjust backend CORS and uvicorn settings

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,4 +19,5 @@ COPY backend/app /app/app
 
 ENV PORT=8000
 EXPOSE 8000
-CMD ["bash", "-lc", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]
+ENV HTTP_TIMEOUT_SECONDS=120
+CMD sh -c 'uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --workers 1 --timeout-keep-alive ${HTTP_TIMEOUT_SECONDS}'

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
 # backend/app/main.py
 
+import os
+
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
@@ -7,7 +9,6 @@ import yaml
 from typing import List, Dict, Any
 
 from shapely.geometry import mapping  # only used for the parcel outline in /export
-from .core.settings import settings
 from .core.logging import get_logger
 
 from .services.arcgis_client import fetch_all_features
@@ -36,10 +37,14 @@ app = FastAPI(
 # --------------------------
 # CORS
 # --------------------------
-origins = [o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()]
+_cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:5173").split(",")
+_cors_origins = [o.strip() for o in _cors_origins if o.strip()]
+if not _cors_origins:
+    _cors_origins = ["http://localhost:5173"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins or ["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
### **User description**
## Summary
- parse FastAPI CORS origins from the `CORS_ORIGINS` environment variable with a localhost fallback and continue allowing all methods and headers
- update the backend Dockerfile to run uvicorn with a single worker and configurable keep-alive timeout for Render deployments

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68c9d93b01648327b9d69dd4347d7b43


___

### **PR Type**
Enhancement


___

### **Description**
- Replace settings-based CORS configuration with environment variable parsing

- Add localhost fallback for CORS origins when none specified

- Update Dockerfile to use single worker uvicorn configuration

- Add configurable HTTP timeout for Render deployment compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] --> B["CORS Configuration"]
  B --> C["FastAPI App"]
  D["Dockerfile"] --> E["Uvicorn Server"]
  E --> F["Single Worker + Timeout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Replace settings-based CORS with environment variable parsing</code></dd></summary>
<hr>

backend/app/main.py

<ul><li>Remove dependency on settings module for CORS configuration<br> <li> Parse CORS origins directly from <code>CORS_ORIGINS</code> environment variable<br> <li> Add localhost fallback when no CORS origins are specified<br> <li> Import <code>os</code> module for environment variable access</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/qlds-mapper-queensla/pull/43/files#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update uvicorn configuration for single worker deployment</code></dd></summary>
<hr>

backend/Dockerfile

<ul><li>Configure uvicorn to run with single worker (<code>--workers 1</code>)<br> <li> Add configurable HTTP timeout via <code>HTTP_TIMEOUT_SECONDS</code> environment <br>variable<br> <li> Update CMD to use shell command with timeout-keep-alive parameter<br> <li> Set default timeout to 120 seconds for deployment compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/qlds-mapper-queensla/pull/43/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

